### PR TITLE
Further Separate `domUpdates` and `scripts`

### DIFF
--- a/src/cookbook.js
+++ b/src/cookbook.js
@@ -13,6 +13,12 @@ class Cookbook {
     })
   }
 
+  filterRecipesByTag(tag) {
+    return this.recipes.filter(recipe => {
+      return recipe.tags.includes(tag);
+    });
+  }
+
   static getIngredients() {
     const ingredientsUrl = 'https://fe-apps.herokuapp.com/api/v1/whats-cookin/1911/ingredients/ingredientsData'
     const promise = fetch(ingredientsUrl)

--- a/src/cookbook.js
+++ b/src/cookbook.js
@@ -9,7 +9,7 @@ class Cookbook {
       return recipe.ingredients.find(ingredient => {
         return (ingredient.name.includes(searchText)) ||
         (recipe.name.includes(searchText))
-      });
+      });x
     })
   }
 

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -1,13 +1,17 @@
 import scripts from './domUpdates';
 
 let domUpdates = {
-  populateCards(recipes, user) {
+  populateCards(recipes, user, userFavorites) {
     let cardArea = document.querySelector('.all-cards');
     cardArea.innerHTML = '';
     if (cardArea.classList.contains('all')) {
       cardArea.classList.remove('all')
     }
     recipes.forEach(recipe => {
+      let buttonStatus;
+      if (userFavorites && userFavorites.includes(recipe.id)) {
+        buttonStatus = `favorite-active`
+      }
       cardArea.insertAdjacentHTML('afterbegin', `
             <div id='${recipe.id}'class='card'>
               <header id='${recipe.id}' class='card-header'>
@@ -20,7 +24,7 @@ let domUpdates = {
                 </button>
                 <label for='favorite-button' class='hidden'>Click to favorite recipe
                 </label>
-                <button id='${recipe.id}' aria-label='favorite-button' class='favorite favorite${recipe.id} card-button'></button>
+                <button id='${recipe.id}' aria-label='favorite-button' class='favorite favorite${recipe.id} ${buttonStatus} card-button'></button>
               </div>
               <span id='${recipe.id}' class='recipe-name'>${recipe.name}</span>
               <img id='${recipe.id}' tabindex='0' class='card-picture'
@@ -30,43 +34,15 @@ let domUpdates = {
           `
       )
     })
-    this.getFavorites(user)
   },
-  viewFavorites(cardArea, user, favButton) {
-    if (cardArea.classList.contains('all')) {
-      cardArea.classList.remove('all')
-    }
+  viewFavorites(cardArea, user, favButton, currentFavs) {
     if (!user.favoriteRecipes.length) {
       favButton.innerHTML = 'You have no favorites!';
-      populateCards(cookbook.recipes);
       return
     } else {
       favButton.innerHTML = 'Refresh Favorites'
       cardArea.innerHTML = '';
-      user.favoriteRecipes.forEach(recipe => {
-        cardArea.insertAdjacentHTML('afterbegin', 
-          `
-        <div id='${recipe.id}'class='card'>
-        <header id='${recipe.id}' class='card-header'>
-        <div class='header-container'>
-          <label for='add-button' class='hidden'></label>
-          <button id='${recipe.id}' aria-label='add-button' class='add-button card-button'>
-            <img id='${recipe.id} favorite' class='add'
-            src='https://image.flaticon.com/icons/svg/32/32339.svg' alt='Add to
-            recipes to cook'>
-          </button>
-          <label for='favorite-button' class='hidden'>Click to favorite recipe
-          </label>
-          <button id='${recipe.id}' aria-label='favorite-button' class='favorite favorite${recipe.id} card-button'></button>
-        </div>
-        <span id='${recipe.id}' class='recipe-name'>${recipe.name}</span>
-        <img id='${recipe.id}' tabindex='0' class='card-picture'
-          src='${recipe.image}' alt='click to view recipe for ${recipe.name}'>
-        </header>
-    </div>
-        `)
-      })
-      this.getFavorites(user)
+      this.populateCards(user.favoriteRecipes, null, currentFavs)
     }
   },
   displayFavorite(specificRecipe, event, favButton) {
@@ -130,10 +106,10 @@ let domUpdates = {
     Welcome ${currentUser.name.split(' ')[0]} ${currentUser.name.split(' ')[1][0]}.`;
   },
   getFavorites(user) {
-    
     if (user.favoriteRecipes) {
       user.favoriteRecipes.forEach(recipe => {
-        document.querySelector(`.favorite${recipe.id}`).classList.add('favorite-active')
+        console.log(recipe)
+        
       })
     } else {
       return

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -1,7 +1,7 @@
 import scripts from './domUpdates';
 
 let domUpdates = {
-  populateCards(recipes) {
+  populateCards(recipes, user) {
     let cardArea = document.querySelector('.all-cards');
     cardArea.innerHTML = '';
     if (cardArea.classList.contains('all')) {
@@ -30,9 +30,9 @@ let domUpdates = {
           `
       )
     })
-    // getFavorites();
+    this.getFavorites(user)
   },
-  viewFavorites() {
+  viewFavorites(cardArea, user, favButton) {
     if (cardArea.classList.contains('all')) {
       cardArea.classList.remove('all')
     }
@@ -66,13 +66,9 @@ let domUpdates = {
     </div>
         `)
       })
+      this.getFavorites(user)
     }
   },
-  // favoriteCard(event) {
-  //   let specificRecipe = cookbook.recipes.find(recipe => {
-  //     if (recipe.id  === Number(event.target.id)) {
-  //       return recipe;
-  //     }
   displayFavorite(specificRecipe, event, favButton) {
     if (!event.target.classList.contains('favorite-active')) {
       event.target.classList.add('favorite-active');
@@ -108,12 +104,12 @@ let domUpdates = {
       `)
     })
   },
-  findRecipeBytag(event) {
+  findRecipeByTag(event, user, cardArea) {
     const tagName = event.target.innerText;
-    const filteredRecipes = user.filterFavoritesByTag(tagName);
+    const filteredRecipes = user.filterFavorites(tagName);
     cardArea.innerHTML = '';
     if (filteredRecipes.length !== 0) {
-      populateCards(filteredRecipes);
+      this.populateCards(filteredRecipes, user);
     }
     return false;
   },
@@ -133,8 +129,9 @@ let domUpdates = {
     userName.innerHTML = `
     Welcome ${currentUser.name.split(' ')[0]} ${currentUser.name.split(' ')[1][0]}.`;
   },
-  getFavorites() {
-    if (user.favoriteRecipes.length) {
+  getFavorites(user) {
+    
+    if (user.favoriteRecipes) {
       user.favoriteRecipes.forEach(recipe => {
         document.querySelector(`.favorite${recipe.id}`).classList.add('favorite-active')
       })

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -1,8 +1,7 @@
 import scripts from './domUpdates';
 
 let domUpdates = {
-  populateCards(recipes, user, userFavorites) {
-    let cardArea = document.querySelector('.all-cards');
+  populateCards(recipes, cardArea, userFavorites) {
     cardArea.innerHTML = '';
     recipes.forEach(recipe => {
       let buttonStatus;
@@ -32,17 +31,17 @@ let domUpdates = {
       )
     })
   },
-  viewFavorites(cardArea, user, favButton, currentFavs) {
+  viewFavorites(cardArea, user, favButton, currentFavs,) {
     if (!user.favoriteRecipes.length) {
       favButton.innerHTML = 'You have no favorites!';
       return
     } else {
       favButton.innerHTML = 'Refresh Favorites'
       cardArea.innerHTML = '';
-      this.populateCards(user.favoriteRecipes, null, currentFavs)
+      this.populateCards(user.favoriteRecipes, cardArea, currentFavs)
     }
   },
-  displayFavorite(specificRecipe, event, favButton) {
+  displayFavorite(event, favButton) {
     if (!event.target.classList.contains('favorite-active')) {
       event.target.classList.add('favorite-active');
       favButton.innerHTML = 'View Favorites';
@@ -77,15 +76,6 @@ let domUpdates = {
       `)
     })
   },
-  findRecipeByTag(event, user, cardArea) {
-    const tagName = event.target.innerText;
-    const filteredRecipes = user.filterFavorites(tagName);
-    cardArea.innerHTML = '';
-    if (filteredRecipes.length !== 0) {
-      this.populateCards(filteredRecipes, user);
-    }
-    return false;
-  },
   updateSearch() {
     let recipeNames = document.querySelectorAll('.recipe-name');
     recipeNames.forEach(recipe =>{
@@ -102,17 +92,6 @@ let domUpdates = {
     userName.innerHTML = `
     Welcome ${currentUser.name.split(' ')[0]} ${currentUser.name.split(' ')[1][0]}.`;
   },
-  getFavorites(user) {
-    if (user.favoriteRecipes) {
-      user.favoriteRecipes.forEach(recipe => {
-        console.log(recipe)
-        
-      })
-    } else {
-      return
-    }
-  },
-  
 }
 export default domUpdates;
 

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -1,3 +1,5 @@
+import scripts from './domUpdates';
+
 let domUpdates = {
   populateCards(recipes) {
     let cardArea = document.querySelector('.all-cards');
@@ -30,17 +32,125 @@ let domUpdates = {
     })
     // getFavorites();
   },
-  cardButtonConditionals(event) {
-    console.log(event.target)
-    if (event.target.classList.contains('favorite')) {
-      favoriteCard(event);
-    } else if (event.target.classList.contains('card-picture')) {
-      displayDirections(event);
-    } else if (event.target.classList.contains('home')) {
-      favButton.innerHTML = 'View Favorites';
-      populateCards(cookbook.recipes);
+  viewFavorites() {
+    if (cardArea.classList.contains('all')) {
+      cardArea.classList.remove('all')
     }
-  }
+    if (!user.favoriteRecipes.length) {
+      favButton.innerHTML = 'You have no favorites!';
+      populateCards(cookbook.recipes);
+      return
+    } else {
+      favButton.innerHTML = 'Refresh Favorites'
+      cardArea.innerHTML = '';
+      user.favoriteRecipes.forEach(recipe => {
+        cardArea.insertAdjacentHTML('afterbegin', 
+          `
+        <div id='${recipe.id}'class='card'>
+        <header id='${recipe.id}' class='card-header'>
+        <div class='header-container'>
+          <label for='add-button' class='hidden'></label>
+          <button id='${recipe.id}' aria-label='add-button' class='add-button card-button'>
+            <img id='${recipe.id} favorite' class='add'
+            src='https://image.flaticon.com/icons/svg/32/32339.svg' alt='Add to
+            recipes to cook'>
+          </button>
+          <label for='favorite-button' class='hidden'>Click to favorite recipe
+          </label>
+          <button id='${recipe.id}' aria-label='favorite-button' class='favorite favorite${recipe.id} card-button'></button>
+        </div>
+        <span id='${recipe.id}' class='recipe-name'>${recipe.name}</span>
+        <img id='${recipe.id}' tabindex='0' class='card-picture'
+          src='${recipe.image}' alt='click to view recipe for ${recipe.name}'>
+        </header>
+    </div>
+        `)
+      })
+    }
+  },
+  // favoriteCard(event) {
+  //   let specificRecipe = cookbook.recipes.find(recipe => {
+  //     if (recipe.id  === Number(event.target.id)) {
+  //       return recipe;
+  //     }
+  displayFavorite(specificRecipe, event, favButton) {
+    if (!event.target.classList.contains('favorite-active')) {
+      event.target.classList.add('favorite-active');
+      favButton.innerHTML = 'View Favorites';
+      return  true
+    } else if (event.target.classList.contains('favorite-active')) {
+      event.target.classList.remove('favorite-active');
+      return false
+    }
+  },
+  displayDirections(event) {
+    let newRecipeInfo = cookbook.recipes.find(recipe => {
+      if (recipe.id === Number(event.target.id)) {
+        return recipe;
+      }
+    })
+    let recipeObject = new Recipe(newRecipeInfo, ingredientsData);
+    let cost = recipeObject.calculateCost()
+    let costInDollars = (cost / 100).toFixed(2)
+    cardArea.classList.add('all');
+    cardArea.innerHTML = `
+      <h3>${recipeObject.name}</h3>
+        <p class='all-recipe-info'>
+        <strong>It will cost: </strong><span class='cost recipe-info'>
+        $${costInDollars}</span><br><br>
+        <strong>You will need: </strong><span class='ingredients recipe-info'></span>
+        <strong>Instructions: </strong><ol><span class='instructions recipe-info'>
+        </span></ol>
+      </p>`;
+    let ingredientsSpan = document.querySelector('.ingredients');
+    let instructionsSpan = document.querySelector('.instructions');
+    recipeObject.ingredients.forEach(ingredient => {
+      ingredientsSpan.insertAdjacentHTML('afterbegin', `<ul><li>
+      ${ingredient.quantity.amount.toFixed(2)} ${ingredient.quantity.unit}
+      ${ingredient.name}</li></ul>
+      `)
+    })
+    recipeObject.instructions.forEach(instruction => {
+      instructionsSpan.insertAdjacentHTML('beforebegin', `<li>
+      ${instruction.instruction}</li>
+      `)
+    })
+  },
+  findRecipeBytag(event) {
+    const tagName = event.target.innerText;
+    const filteredRecipes = user.filterFavoritesByTag(tagName);
+    cardArea.innerHTML = '';
+    if (filteredRecipes.length !== 0) {
+      populateCards(filteredRecipes);
+    }
+    return false;
+  },
+  updateSearch() {
+    let recipeNames = document.querySelectorAll('.recipe-name');
+    recipeNames.forEach(recipe =>{
+      let lowerCaseRecipe = recipe.innerText.toLowerCase()
+      if (!lowerCaseRecipe.includes(searchInput.value)) {
+        document.getElementById(recipe.id).classList.add("hidden")
+      } else {
+        document.getElementById(recipe.id).classList.remove("hidden");
+      }
+    })
+  },
+  greetUser(currentUser) {
+    const userName = document.querySelector('.user-name');
+    userName.innerHTML = `
+    Welcome ${currentUser.name.split(' ')[0]} ${currentUser.name.split(' ')[1][0]}.`;
+  },
+  getFavorites() {
+    if (user.favoriteRecipes.length) {
+      user.favoriteRecipes.forEach(recipe => {
+        document.querySelector(`.favorite${recipe.id}`).classList.add('favorite-active')
+      })
+    } else {
+      return
+    }
+  },
+  
 }
 export default domUpdates;
 

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -4,9 +4,6 @@ let domUpdates = {
   populateCards(recipes, user, userFavorites) {
     let cardArea = document.querySelector('.all-cards');
     cardArea.innerHTML = '';
-    if (cardArea.classList.contains('all')) {
-      cardArea.classList.remove('all')
-    }
     recipes.forEach(recipe => {
       let buttonStatus;
       if (userFavorites && userFavorites.includes(recipe.id)) {

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -83,15 +83,7 @@ let domUpdates = {
       return false
     }
   },
-  displayDirections(event) {
-    let newRecipeInfo = cookbook.recipes.find(recipe => {
-      if (recipe.id === Number(event.target.id)) {
-        return recipe;
-      }
-    })
-    let recipeObject = new Recipe(newRecipeInfo, ingredientsData);
-    let cost = recipeObject.calculateCost()
-    let costInDollars = (cost / 100).toFixed(2)
+  displayDirections(cardArea, recipeObject, costInDollars) {
     cardArea.classList.add('all');
     cardArea.innerHTML = `
       <h3>${recipeObject.name}</h3>

--- a/src/pantry.js
+++ b/src/pantry.js
@@ -69,6 +69,7 @@ class Pantry {
 
   calculateCost(recipe) {
     let list = this.calculateIngredientsNeeded(recipe)
+    console.log(this)
     let costCounter = 0;
     list.forEach(ingredient => {
       let ingredientData = recipe.ingredientsData.find(recipeIng => { 

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -17,7 +17,7 @@ const searchInput = document.querySelector('#inpt_search');
 const tagContainer = document.querySelector('.tag-container');
 const cardArea = document.querySelector('.all-cards');
 
-homeButton.addEventListener('click', cardButtonConditionals);
+homeButton.addEventListener('click', homeHandler);
 cardArea.addEventListener('click', cardButtonConditionals);
 favButton.addEventListener('click', determineFavorites);
 searchInput.addEventListener('input', domUpdates.updateSearch);
@@ -63,16 +63,18 @@ function tagHandler(event) {
   domUpdates.findRecipeByTag(event, currentUser, cardArea)
 }
 
+function homeHandler() {
+  favButton.innerHTML = 'View Favorites';
+  let currentFavs = currentUser.favoriteRecipes.map(x => x.id)
+  domUpdates.populateCards(cookbook.recipes, currentUser,  currentFavs);
+}
+
 function cardButtonConditionals(event) {
   if (event.target.classList.contains('favorite')) {
     favoriteCard(event);
   } else if (event.target.classList.contains('card-picture')) {
     findDirections(event);
-  } else if (event.target.classList.contains('home')) {
-    favButton.innerHTML = 'View Favorites';
-    let currentFavs = currentUser.favoriteRecipes.map(x => x.id)
-    domUpdates.populateCards(cookbook.recipes, currentUser,  currentFavs);
-  }
+  } 
 }
 
 

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -65,10 +65,11 @@ function determineFavorites() {
 function tagHandler(event) {
   let filteredRecipes;
   const tagName = event.target.innerText;
-  if (document.querySelectorAll('.favorite-active').length) {
-    filteredRecipes = currentUser.filterFavorites(tagName)
-  }else {
+  if (!currentUser.favoriteRecipes.length) {
     filteredRecipes = cookbook.filterRecipesByTag(tagName)
+    console.log(currentUser.favoriteRecipes)
+  }else {
+    filteredRecipes = currentUser.filterFavorites(tagName)
   }
   domUpdates.populateCards(filteredRecipes, cardArea, currentFavs())
 }

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -65,11 +65,10 @@ function determineFavorites() {
 function tagHandler(event) {
   let filteredRecipes;
   const tagName = event.target.innerText;
-  if (!currentUser.favoriteRecipes.length) {
-    filteredRecipes = cookbook.filterRecipesByTag(tagName)
-    console.log(currentUser.favoriteRecipes)
-  }else {
+  if (document.querySelector('.view-favorites').innerText === 'Refresh Favorites' ) {
     filteredRecipes = currentUser.filterFavorites(tagName)
+  } else {
+    filteredRecipes = cookbook.filterRecipesByTag(tagName)
   }
   domUpdates.populateCards(filteredRecipes, cardArea, currentFavs())
 }

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -34,7 +34,7 @@ function onStartup() {
       cookbook = new Cookbook(values[1].recipeData, values[0].ingredientsData)
       currentUser = new User(values[2])
       domUpdates.greetUser(currentUser)
-      domUpdates.populateCards(cookbook.recipes, currentUser)
+      domUpdates.populateCards(cookbook.recipes, cardArea)
     })
 }
 
@@ -42,7 +42,7 @@ function favoriteCard(event) {
   let specificRecipe = cookbook.recipes.find(recipe => {
     return recipe.id  === Number(event.target.id)
   })
-  let favoriteStatus = domUpdates.displayFavorite(specificRecipe, event, favButton)
+  let favoriteStatus = domUpdates.displayFavorite(event, favButton)
   favoriteStatus ? currentUser.addToFavorites(specificRecipe) : currentUser.removeFromFavorites(specificRecipe)
 }
 
@@ -54,19 +54,28 @@ function findDirections() {
   domUpdates.displayDirections(cardArea, recipeObject, costInDollars)
 }
 
+function currentFavs() {
+  return currentUser.favoriteRecipes.map(recipe => recipe.id)
+}
+
 function determineFavorites() {
-  let currentFavs = currentUser.favoriteRecipes.map(x => x.id)
-  domUpdates.viewFavorites(cardArea, currentUser, favButton, currentFavs)
+  domUpdates.viewFavorites(cardArea, currentUser, favButton, currentFavs())
 }
 
 function tagHandler(event) {
-  domUpdates.findRecipeByTag(event, currentUser, cardArea)
+  let filteredRecipes;
+  const tagName = event.target.innerText;
+  if (document.querySelectorAll('.favorite-active').length) {
+    filteredRecipes = currentUser.filterFavorites(tagName)
+  }else {
+    filteredRecipes = cookbook.filterRecipesByTag(tagName)
+  }
+  domUpdates.populateCards(filteredRecipes, cardArea, currentFavs())
 }
-
+  
 function homeHandler() {
   favButton.innerHTML = 'View Favorites';
-  let currentFavs = currentUser.favoriteRecipes.map(x => x.id)
-  domUpdates.populateCards(cookbook.recipes, currentUser,  currentFavs);
+  domUpdates.populateCards(cookbook.recipes, cardArea, currentFavs());
 }
 
 function cardButtonConditionals(event) {

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -8,7 +8,7 @@ import Recipe from './recipe';
 import User from './user';
 import Cookbook from './cookbook';
 import domUpdates from './domUpdates';
-let cookbook, user;
+let cookbook, currentUser, userPantry;
 
 window.onload = onStartup();
 const favButton = document.querySelector('.view-favorites');
@@ -41,12 +41,10 @@ function populateCookBook() {
 
 function populateUserData() {
   let userId = (Math.floor(Math.random() * 49) + 1)
-  let currentUser, userPantry
   User.getUserData(userId) 
-    .then(data => currentUser = data)
+    .then(data => currentUser = new User(data))
     .then(() => domUpdates.greetUser(currentUser))
     .then(() => userPantry = new Pantry(currentUser.pantry))
-    .then(() => console.log(userPantry))
 }
 function favoriteCard(event) {
   console.log(cookbook)
@@ -54,7 +52,15 @@ function favoriteCard(event) {
     return recipe.id  === Number(event.target.id)
   })
   let favoriteStatus = domUpdates.displayFavorite(specificRecipe, event, favButton)
-  favoriteStatus ? user.addToFavorites(specificRecipe) :user.removeFromFavorites(specificRecipe)
+  favoriteStatus ? currentUser.addToFavorites(specificRecipe) : currentUser.removeFromFavorites(specificRecipe)
+}
+
+function findDirections() {
+  let newRecipeInfo = cookbook.recipes.find(recipe => recipe.id === Number(event.target.id))
+  let recipeObject = new Recipe(newRecipeInfo, ingredientsData);
+  let cost = recipeObject.calculateCost()
+  let costInDollars = (cost / 100).toFixed(2)
+  domUpdates.displayDirections(cardArea, recipeObject, costInDollars)
 }
 
 function cardButtonConditionals(event) {
@@ -62,7 +68,7 @@ function cardButtonConditionals(event) {
   if (event.target.classList.contains('favorite')) {
     favoriteCard(event);
   } else if (event.target.classList.contains('card-picture')) {
-    domUpdates.displayDirections(event);
+    findDirections(event);
   } else if (event.target.classList.contains('home')) {
     favButton.innerHTML = 'View Favorites';
     domUpdates.populateCards(cookbook.recipes);

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -8,19 +8,21 @@ import Recipe from './recipe';
 import User from './user';
 import Cookbook from './cookbook';
 import domUpdates from './domUpdates';
+let cookbook, user;
 
-let favButton = document.querySelector('.view-favorites');
-let homeButton = document.querySelector('.home')
-let searchInput = document.querySelector('#inpt_search');
-const tagContainer = document.querySelector('.tag-container');
-let cardArea = document.querySelector('.all-cards');
 window.onload = onStartup();
+const favButton = document.querySelector('.view-favorites');
+const homeButton = document.querySelector('.home')
+const searchInput = document.querySelector('#inpt_search');
+const tagContainer = document.querySelector('.tag-container');
+const cardArea = document.querySelector('.all-cards');
 
-homeButton.addEventListener('click', domUpdates.cardButtonConditionals);
-cardArea.addEventListener('click', domUpdates.cardButtonConditionals);
-favButton.addEventListener('click', viewFavorites);
-searchInput.addEventListener('input', updateSearch);
-tagContainer.addEventListener('click', findRecipeBytag);
+homeButton.addEventListener('click', cardButtonConditionals);
+cardArea.addEventListener('click', cardButtonConditionals);
+favButton.addEventListener('click', domUpdates.viewFavorites);
+searchInput.addEventListener('input', domUpdates.updateSearch);
+tagContainer.addEventListener('click', domUpdates.findRecipeBytag);
+
 
 function onStartup() {
   populateCookBook();
@@ -30,11 +32,11 @@ function onStartup() {
 function populateCookBook() {
   let ingredients, recipes;
   Cookbook.getIngredients()
-    .then(data => ingredients = data)
+    .then(data => ingredients = data.ingredientsData)
   Cookbook.getRecipes()
-    .then(data => recipes = data)
-    .then(() => new Cookbook(recipes, ingredients))
-    .then(data =>  domUpdates.populateCards(data.recipes.recipeData))
+    .then(data => recipes = data.recipeData)
+    .then(() => cookbook = new Cookbook(recipes, ingredients))
+    .then(data =>  domUpdates.populateCards(data.recipes))
 }
 
 function populateUserData() {
@@ -42,140 +44,31 @@ function populateUserData() {
   let currentUser, userPantry
   User.getUserData(userId) 
     .then(data => currentUser = data)
-    .then(() => greetUser(currentUser))
+    .then(() => domUpdates.greetUser(currentUser))
     .then(() => userPantry = new Pantry(currentUser.pantry))
     .then(() => console.log(userPantry))
 }
-
-function viewFavorites() {
-  if (cardArea.classList.contains('all')) {
-    cardArea.classList.remove('all')
-  }
-  if (!user.favoriteRecipes.length) {
-    favButton.innerHTML = 'You have no favorites!';
-    populateCards(cookbook.recipes);
-    return
-  } else {
-    favButton.innerHTML = 'Refresh Favorites'
-    cardArea.innerHTML = '';
-    user.favoriteRecipes.forEach(recipe => {
-      cardArea.insertAdjacentHTML('afterbegin', 
-        `
-      <div id='${recipe.id}'class='card'>
-      <header id='${recipe.id}' class='card-header'>
-      <div class='header-container'>
-        <label for='add-button' class='hidden'></label>
-        <button id='${recipe.id}' aria-label='add-button' class='add-button card-button'>
-          <img id='${recipe.id} favorite' class='add'
-          src='https://image.flaticon.com/icons/svg/32/32339.svg' alt='Add to
-          recipes to cook'>
-        </button>
-        <label for='favorite-button' class='hidden'>Click to favorite recipe
-        </label>
-        <button id='${recipe.id}' aria-label='favorite-button' class='favorite favorite${recipe.id} card-button'></button>
-      </div>
-      <span id='${recipe.id}' class='recipe-name'>${recipe.name}</span>
-      <img id='${recipe.id}' tabindex='0' class='card-picture'
-        src='${recipe.image}' alt='click to view recipe for ${recipe.name}'>
-      </header>
-  </div>
-      `)
-    })
-  }
-}
-
-function greetUser(currentUser) {
-  const userName = document.querySelector('.user-name');
-  userName.innerHTML = `
-  Welcome ${currentUser.name.split(' ')[0]} ${currentUser.name.split(' ')[1][0]}.`;
-}
-
 function favoriteCard(event) {
+  console.log(cookbook)
   let specificRecipe = cookbook.recipes.find(recipe => {
-    if (recipe.id  === Number(event.target.id)) {
-      return recipe;
-    }
+    return recipe.id  === Number(event.target.id)
   })
-  if (!event.target.classList.contains('favorite-active')) {
-    event.target.classList.add('favorite-active');
+  let favoriteStatus = domUpdates.displayFavorite(specificRecipe, event, favButton)
+  favoriteStatus ? user.addToFavorites(specificRecipe) :user.removeFromFavorites(specificRecipe)
+}
+
+function cardButtonConditionals(event) {
+  console.log(event.target)
+  if (event.target.classList.contains('favorite')) {
+    favoriteCard(event);
+  } else if (event.target.classList.contains('card-picture')) {
+    domUpdates.displayDirections(event);
+  } else if (event.target.classList.contains('home')) {
     favButton.innerHTML = 'View Favorites';
-    user.addToFavorites(specificRecipe);
-  } else if (event.target.classList.contains('favorite-active')) {
-    event.target.classList.remove('favorite-active');
-    user.removeFromFavorites(specificRecipe)
+    domUpdates.populateCards(cookbook.recipes);
   }
 }
 
 
 
 
-function displayDirections(event) {
-  let newRecipeInfo = cookbook.recipes.find(recipe => {
-    if (recipe.id === Number(event.target.id)) {
-      return recipe;
-    }
-  })
-  let recipeObject = new Recipe(newRecipeInfo, ingredientsData);
-  let cost = recipeObject.calculateCost()
-  let costInDollars = (cost / 100).toFixed(2)
-  cardArea.classList.add('all');
-  cardArea.innerHTML = `
-    <h3>${recipeObject.name}</h3>
-      <p class='all-recipe-info'>
-      <strong>It will cost: </strong><span class='cost recipe-info'>
-      $${costInDollars}</span><br><br>
-      <strong>You will need: </strong><span class='ingredients recipe-info'></span>
-      <strong>Instructions: </strong><ol><span class='instructions recipe-info'>
-      </span></ol>
-    </p>`;
-
-
-  let ingredientsSpan = document.querySelector('.ingredients');
-  let instructionsSpan = document.querySelector('.instructions');
-  recipeObject.ingredients.forEach(ingredient => {
-    ingredientsSpan.insertAdjacentHTML('afterbegin', `<ul><li>
-    ${ingredient.quantity.amount.toFixed(2)} ${ingredient.quantity.unit}
-    ${ingredient.name}</li></ul>
-    `)
-  })
-  recipeObject.instructions.forEach(instruction => {
-    instructionsSpan.insertAdjacentHTML('beforebegin', `<li>
-    ${instruction.instruction}</li>
-    `)
-  })
-}
-
-function getFavorites() {
-  if (user.favoriteRecipes.length) {
-    user.favoriteRecipes.forEach(recipe => {
-      document.querySelector(`.favorite${recipe.id}`).classList.add('favorite-active')
-    })
-  } else {
-    return
-  }
-}
-
-
-
-function findRecipeBytag(event) {
-  const tagName = event.target.innerText;
-  const filteredRecipes = user.filterFavoritesByTag(tagName);
-  cardArea.innerHTML = '';
-  if (filteredRecipes.length !== 0) {
-    populateCards(filteredRecipes);
-  }
-  return false;
-}
-
-function updateSearch() {
-  let recipeNames = document.querySelectorAll('.recipe-name');
-  recipeNames.forEach(recipe =>{
-    let lowerCaseRecipe = recipe.innerText.toLowerCase()
-    if (!lowerCaseRecipe.includes(searchInput.value)) {
-      document.getElementById(recipe.id).classList.add("hidden")
-    } else {
-      document.getElementById(recipe.id).classList.remove("hidden");
-    }
-  })
-  
-}

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -39,7 +39,6 @@ function onStartup() {
 }
 
 function favoriteCard(event) {
-  console.log(cookbook)
   let specificRecipe = cookbook.recipes.find(recipe => {
     return recipe.id  === Number(event.target.id)
   })
@@ -56,7 +55,8 @@ function findDirections() {
 }
 
 function determineFavorites() {
-  domUpdates.viewFavorites(cardArea, currentUser, favButton)
+  let currentFavs = currentUser.favoriteRecipes.map(x => x.id)
+  domUpdates.viewFavorites(cardArea, currentUser, favButton, currentFavs)
 }
 
 function tagHandler(event) {
@@ -64,14 +64,14 @@ function tagHandler(event) {
 }
 
 function cardButtonConditionals(event) {
-  console.log(event.target)
   if (event.target.classList.contains('favorite')) {
     favoriteCard(event);
   } else if (event.target.classList.contains('card-picture')) {
     findDirections(event);
   } else if (event.target.classList.contains('home')) {
     favButton.innerHTML = 'View Favorites';
-    domUpdates.populateCards(cookbook.recipes, currentUser);
+    let currentFavs = currentUser.favoriteRecipes.map(x => x.id)
+    domUpdates.populateCards(cookbook.recipes, currentUser,  currentFavs);
   }
 }
 


### PR DESCRIPTION
### PR Template:
#### What’s this PR do?  

- This PR further separates the scripts and domUpdates files
- This PR refactors some redundant code from domUpdates 
- This PR utilizes the `populateCards` method to handle tag and favorite card population after various events.
 
#### Where should the reviewer start?  

- Review Scripts to see where all the dom manipulation is being done
- Review domUpdates to see what methods have been removed/refactored
 
#### How should this be manually tested?  

- Start a local server and check for any bugs, the tag functionality should now work for both favorites and non favorites alike
- Visual feedback for favorites should now persist after all events other than refresh, in accordance with `currentUsers` favorite recipes
 
#### Any background context you want to provide?  

- populateCards may be a little too involved, may need to split this up a bit
 
#### What are the relevant tickets?  

#17 #18 
 
#### next Step:

- work on getting search bar functionality fixed
