### PR TITLE
Add ingredients to search

### DIFF
--- a/src/cookbook.js
+++ b/src/cookbook.js
@@ -5,11 +5,12 @@ class Cookbook {
   }
 
   findRecipe(searchText) {
+    let filteredRecipes = this.ingredients.filter(x => x.name).filter(x => x.name.includes(searchText)).map(x => x.id)
     return this.recipes.filter(recipe => {
       return recipe.ingredients.find(ingredient => {
-        return (ingredient.name.includes(searchText)) ||
-        (recipe.name.includes(searchText))
-      });x
+        return (filteredRecipes.includes(ingredient.id)) ||
+      (recipe.name.includes(searchText))
+      });
     })
   }
 

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -104,18 +104,17 @@ class DomUpdates {
     })
   }
 
-  updateSearchByRecipeName(inputByUser) {
-    const recipeCards = document.querySelectorAll('.recipe-name')
-    const lowerInput = inputByUser.toLowerCase()
+  updateSearchByRecipeName(results) {
+    const recipeCards = document.querySelectorAll('.card')
     recipeCards.forEach(recipe => {
-      let lowerCaseRecipe = recipe.innerText.toLowerCase()
-        if (!lowerCaseRecipe.includes(lowerInput)) {
-          document.getElementById(recipe.id).classList.add("hidden")
-          } else {
-            document.getElementById(recipe.id).classList.remove("hidden");
-          }
-      })
-  }
+      if (!results.includes(+recipe.id)) {
+        document.getElementById(recipe.id).classList.add("hidden")
+      } else {
+        document.getElementById(recipe.id).classList.remove("hidden");
+      }
+  })
+}
+
 
   updateSearchByIngredientName(inputByUser, cookbook){
     const lowerCaseInput = inputByUser.toLowerCase()
@@ -129,7 +128,7 @@ class DomUpdates {
     // console.log(cookbook.ingredients)
 
     //if I am able to returnt the id I should be able to target the recipes and do the add and remove hidden
-}
+  }
 
 
   greetUser(currentUser) {
@@ -140,6 +139,7 @@ class DomUpdates {
   }
 
   displayIngredientFeedback(feedback, id) {
+    console.log(feedback)
     let card = document.getElementById(id)
     // let name = document.getElementById(`${id} name`)
     card.innerHTML = ``;
@@ -169,7 +169,7 @@ class DomUpdates {
     <button class='cooked ' id='${id}'>Check when cooked</button>
     <i class="fas fa-arrow-circle-left back-button"></i>
     `)
- }
+  }
 }
 
 export default DomUpdates;

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -112,22 +112,7 @@ class DomUpdates {
       } else {
         document.getElementById(recipe.id).classList.remove("hidden");
       }
-  })
-}
-
-
-  updateSearchByIngredientName(inputByUser, cookbook){
-    const lowerCaseInput = inputByUser.toLowerCase()
-    
-    //by iterating through the cookbook.ingredients => ing names || ing.name 
-    //when the user types milk => i should me able to find the ing id
-    //iterating through the coobkbook.recipes[]/map(e => e.ingredient.includes(ing.id)find the recipe the recipe)
-    const ingredientsNames = cookbook.ingredients.map(ingredient => ingredient.name) //array of names
-    const ingredientsIds = cookbook.ingredients.map(ingredient => ingredient.id) //array of ids
-    //find the id of the ingredient input by the user
-    // console.log(cookbook.ingredients)
-
-    //if I am able to returnt the id I should be able to target the recipes and do the add and remove hidden
+    })
   }
 
 

--- a/src/index.html
+++ b/src/index.html
@@ -1,5 +1,3 @@
-</body>
-</html>
 <!DOCTYPE html>
 <html lang='en'>
   <head>

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -24,7 +24,6 @@ const displaySearch = () => {
   let results = cookbook.findRecipe(inputByUser).map(recipe => recipe.id)
   console.log(results)
   domUpdates.updateSearchByRecipeName(results)
-  // domUpdates.updateSearchByTagName(inputByUser, cookbook)
 }
 
 const addToCookLater = (event) => {

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -22,7 +22,6 @@ const domUpdates = new DomUpdates();
 const displaySearch = () => {
   const inputByUser = searchInput.value
   let results = cookbook.findRecipe(inputByUser).map(recipe => recipe.id)
-  console.log(results)
   domUpdates.updateSearchByRecipeName(results)
 }
 

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -21,9 +21,10 @@ const domUpdates = new DomUpdates();
 
 const displaySearch = () => {
   const inputByUser = searchInput.value
-  const searchParent = document.querySelector('.cntr')
-  domUpdates.updateSearchByRecipeName(inputByUser)
-  domUpdates.updateSearchByTagName(inputByUser, cookbook)
+  let results = cookbook.findRecipe(inputByUser).map(recipe => recipe.id)
+  console.log(results)
+  domUpdates.updateSearchByRecipeName(results)
+  // domUpdates.updateSearchByTagName(inputByUser, cookbook)
 }
 
 const addToCookLater = (event) => {

--- a/test/cookbook-test.js
+++ b/test/cookbook-test.js
@@ -2,21 +2,22 @@ import {expect} from 'chai';
 
 
 import recipeData from '../src/data/recipes';
+import ingredientData from '../src/data/ingredients';
 import Cookbook from '../src/cookbook';
 
 let cookbook;
 
 describe('Cookbook', () => {
   beforeEach(() => {
-    cookbook = new Cookbook(recipeData);
+    cookbook = new Cookbook(recipeData, ingredientData);
   });
 
   it('Should be a function', () => {
-   expect(Cookbook).to.be.a('function');
+    expect(Cookbook).to.be.a('function');
   });
 
   it('Should be an instance of Cookbook', () => {
-   expect(cookbook).to.be.an.instanceof(Cookbook)
+    expect(cookbook).to.be.an.instanceof(Cookbook)
   });
 
   it('Should have an array of all recipes', () => {


### PR DESCRIPTION
### PR Template:
#### What’s this PR do?  

- Increases functionality of search function to include ingredients *and* recipes 
- Refactors relevant tests / removes excess code
 
#### Where should the reviewer start?  

- displaySearch updated in scripts

- updateSearchByRecipeName updated in domUpdates

- findRecipe updated in cookbook / tests refactored 


#### How should this be manually tested?  

- Type in the search bar, typing in "garlic" for example, ill now bring up all ingredients that have garlic in the name and include garlic as a recipe.
 
#### Any background context you want to provide?  

- Utilized the method on cookbook that we were previously ignoring. 
 
#### What are the relevant tickets?  

closes #8 
 